### PR TITLE
Called the incorrect function for filtering above

### DIFF
--- a/frontend_files/DiscordBot/discord_bot.py
+++ b/frontend_files/DiscordBot/discord_bot.py
@@ -177,7 +177,7 @@ async def below_error(ctx,error):
 async def above(ctx,arg):
     transac = ""
 
-    for tups in filter_below(str(arg)):
+    for tups in filter_above(str(arg)):
         for tup in tups:
             transac += str(tup) + "\t\t\t"
         transac += "\n"


### PR DESCRIPTION
The bot was filtering incorrectly due to using the below function rather than the above function. The typo has been changed to the correct one. 